### PR TITLE
Remove typing as explicit dependency for recent python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requirements = [
     'attr',
     'numpy',
     'sympy',
-    'typing',
+    'typing; python_version < "3.5.0"';
 ]
 
 setuptools.setup(


### PR DESCRIPTION
The `typing` package has been in the [standard library](https://docs.python.org/3/library/typing.html) since 3.5, so there should be no need to include it as a separate dependency on recent versions of python (we could also just remove the dependency entirely if support for python 3.4 and earlier is not needed). Installing the standalone typing package can lead to weird errors like https://github.com/ethereum/eth-abi/issues/131.