### PR TITLE
Allow overconstraining a System.

### DIFF
--- a/constraintula_test.py
+++ b/constraintula_test.py
@@ -102,6 +102,20 @@ def test_constrain_with_vanilla_class():
     assert isinstance(baz, Baz)
 
 
+def test_fail_on_overconstrian():
+    x, y, z = constraintula.symbols('x y z')
+
+    @constraintula.constrain([x * y - z])
+    class Baz:
+        def __init__(self, x, y, z):
+            self.x = x
+            self.y = y
+            self.z = z
+
+    with pytest.raises(ValueError):
+        baz = Baz(x=3, y=3, z=9)
+
+
 def test_overrides():
     x, y, z = constraintula.symbols('x y z')
 

--- a/constraintula_test.py
+++ b/constraintula_test.py
@@ -102,6 +102,23 @@ def test_constrain_with_vanilla_class():
     assert isinstance(baz, Baz)
 
 
+def test_overrides():
+    x, y, z = constraintula.symbols('x y z')
+
+    @constraintula.constrain([x * y - z], allow_overrides=True)
+    class Baz:
+        def __init__(self, x, y, z):
+            self.x = x
+            self.y = y
+            self.z = z
+
+    # pylint: disable=no-value-for-parameter
+    baz = Baz(x=3, y=3, z=9)
+    # pylint: enable=no-value-for-parameter
+    assert math.isclose(baz.y, 3)
+    assert isinstance(baz, Baz)
+
+
 def test_constrain_with_properties():
     x, y, z = constraintula.symbols('x y z')
 


### PR DESCRIPTION
We add a feature allowing us to overconstrain the system, e.g.
```python
@constrain([radius - 2 * diameter], allow_overrides=True)
class Circle:
    def __init__(self, radius, diameter):
        self.radius = radius
        self.diameter = diameter

my_circle = Circle(radius=1, diameter=2)
```
If allow_overrides were False (the default), then this code
would raise an error because the circle is over-constrained.

Note that allow_overrides=True makes it possible to create
inconsistent data, i.e. this will not raise an error:
```python
my_circle = Circle(radius=1, diameter=-4)
```
This feature is introduced purely to allow migrating old code
where all parameters are pre-computed before instancing a
class.